### PR TITLE
Increase GitHub Action checkout version to v5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,8 @@ jobs:
     container: fedora:41  # CURRENT DEVELOPMENT ENVIRONMENT
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Install dependencies
         run: >
           dnf install -y
@@ -82,6 +84,8 @@ jobs:
       - name: Display Python version
         run: python3 --version
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Install dependencies
         run: >
           dnf install -y

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     container: fedora:41  # CURRENT DEVELOPMENT ENVIRONMENT
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install dependencies
         run: >
           dnf install -y
@@ -81,7 +81,7 @@ jobs:
           10
       - name: Display Python version
         run: python3 --version
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install dependencies
         run: >
           dnf install -y


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/807

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflows to use the latest checkout action, aligning with upstream improvements and reliability updates.
  * Modified checkout steps to avoid persisting credentials between steps, enhancing CI security without changing build or deployment behavior.
  * No user-facing changes; functionality and performance of the product remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->